### PR TITLE
fix nebula joining error when client left game while in space

### DIFF
--- a/Scripts/Patches/GuideMissionStandardMode/Skip.cs
+++ b/Scripts/Patches/GuideMissionStandardMode/Skip.cs
@@ -37,6 +37,11 @@ namespace GalacticScale
                 {
                     __instance.gameData.localPlanet = GameMain.localPlanet;
                 }
+                else if (NebulaAPI.NebulaModAPI.IsMultiplayerActive && NebulaAPI.NebulaModAPI.MultiplayerSession.LocalPlayer.IsClient)
+                {
+                    // let clients join in space if they want to
+                    return false;
+                }
                 else
                 {
                     __instance.gameData.ArrivePlanet(__instance.gameData.galaxy.PlanetById(__instance.gameData.galaxy.birthPlanetId));
@@ -50,11 +55,14 @@ namespace GalacticScale
             __instance.targetUPos = __instance.localPlanet.uPosition + (VectorLF3)(__instance.localPlanet.runtimeRotation * __instance.targetPos);
             __instance.targetRot = Maths.SphericalRotation(__instance.localPlanet.birthPoint, 0.0f);
             __instance.targetURot = __instance.localPlanet.runtimeRotation * __instance.targetRot;
-            __instance.localPlanet.factory.FlattenTerrain(__instance.targetPos, __instance.targetRot, new Bounds(Vector3.zero, new Vector3(10f, 5f, 10f)), removeVein: true, lift: true);
-            GS2.Log("Waking in SpacePod");
-            __instance.CreateSpaceCapsuleVegetable();
-            GS2.Log("Searching for landing place");
-            __instance.gameData.InitLandingPlace();
+            if(__instance.localPlanet.factory != null)
+            {
+                __instance.localPlanet.factory.FlattenTerrain(__instance.targetPos, __instance.targetRot, new Bounds(Vector3.zero, new Vector3(10f, 5f, 10f)), removeVein: true, lift: true);
+                GS2.Log("Waking in SpacePod");
+                __instance.CreateSpaceCapsuleVegetable();
+                GS2.Log("Searching for landing place");
+                __instance.gameData.InitLandingPlace();
+            }
             __instance.player.controller.memCameraTargetRot = __instance.targetRot;
             __instance.player.cameraTarget.rotation = __instance.targetRot;
             // if (GS2.Config.CheatMode && !GS2.ResearchUnlocked)

--- a/Scripts/Patches/PlanetSimulator/UpdateUniversalPosition.cs
+++ b/Scripts/Patches/PlanetSimulator/UpdateUniversalPosition.cs
@@ -90,9 +90,9 @@ namespace GalacticScale
             if (__instance.surfaceRenderer != null && __instance.surfaceRenderer.Length > 0)
             {
                 var sharedMaterial = __instance.surfaceRenderer[0].sharedMaterial;
-                sharedMaterial.SetVector("_SunDir", vector3_2);
-                sharedMaterial.SetVector("_Rotation", new Vector4(localRotation.x, localRotation.y, localRotation.z, localRotation.w));
-                sharedMaterial.SetFloat("_Distance", magnitude);
+                sharedMaterial?.SetVector("_SunDir", vector3_2);
+                sharedMaterial?.SetVector("_Rotation", new Vector4(localRotation.x, localRotation.y, localRotation.z, localRotation.w));
+                sharedMaterial?.SetFloat("_Distance", magnitude);
             }
 
             if (__instance.reformRenderer != null && __instance.reformMat0 != null && __instance.reformMat0 != null && __instance.planetData.factory != null)


### PR DESCRIPTION
Solves an error that happens when clients using nebula leave the game while they are in space and then want to rejoin.

Also adds a check to avoid the following error:
```NullReferenceException: Object reference not set to an instance of an object
GalacticScale.PatchOnPlanetSimulator.UpdateUniversalPosition (PlanetSimulator& __instance, StarSimulator& ___star, System.Boolean& ___isLocal, UnityEngine.Transform& ___lookCamera, UnityEngine.Vector3 playerLPos, VectorLF3 playerUPos, UnityEngine.Vector3 cameraPos) (at <b49e12284a494eddb429e6668fb34ede>:IL_03E5)
PlanetSimulator.UpdateUniversalPosition (UnityEngine.Vector3 playerLPos, VectorLF3 playerUPos, UnityEngine.Vector3 cameraPos) (at <223ad7a8c9634815903ae66b31e1f398>:IL_0005)
UniverseSimulator.GameTick (System.Double time) (at <223ad7a8c9634815903ae66b31e1f398>:IL_00DD)
GameMain.FixedUpdate () (at <223ad7a8c9634815903ae66b31e1f398>:IL_0120)```