### PR TITLE
Make NebulaAPI soft dependency

### DIFF
--- a/Bootstrap.cs
+++ b/Bootstrap.cs
@@ -17,7 +17,7 @@ namespace GalacticScale
 
     [BepInPlugin("dsp.galactic-scale.2", "Galactic Scale 2 Plug-In", "2.3.7")]
     [BepInDependency("space.customizing.console", BepInDependency.DependencyFlags.SoftDependency)]
-    [BepInDependency(NebulaAPI.NebulaModAPI.API_GUID)]
+    [BepInDependency("dsp.nebula-multiplayer-api", BepInDependency.DependencyFlags.SoftDependency)]
     public class Bootstrap : BaseUnityPlugin
     {
         public new static ManualLogSource Logger;

--- a/Scripts/Init.cs
+++ b/Scripts/Init.cs
@@ -21,7 +21,6 @@ namespace GalacticScale
         public static bool canvasOverlay = false;
         public static Image splashImage;
         public static bool SaveOrLoadWindowOpen = false;
-        public static bool NebulaClient = false;
         public static bool Initialized = false;
         public static bool MenuHasLoaded;
 

--- a/Scripts/Models/Packets/LobbyRequestUpdateSolarSystemsProcessor.cs
+++ b/Scripts/Models/Packets/LobbyRequestUpdateSolarSystemsProcessor.cs
@@ -1,7 +1,8 @@
 ﻿using System.IO;
 using NebulaAPI;
+using GalacticScale;
 
-namespace GalacticScale
+namespace NebulaCompatibility
 {
     [RegisterPacketProcessor]
     public class LobbyRequestUpdateSolarSystemsProcessor : BasePacketProcessor<LobbyRequestUpdateSolarSystems>

--- a/Scripts/Models/Packets/LobbyResponseUpdateSolarSystemsProcessor.cs
+++ b/Scripts/Models/Packets/LobbyResponseUpdateSolarSystemsProcessor.cs
@@ -1,7 +1,8 @@
 ﻿using System.IO;
 using NebulaAPI;
+using GalacticScale;
 
-namespace GalacticScale
+namespace NebulaCompatibility
 {
     [RegisterPacketProcessor]
     public class LobbyResponseUpdateSolarSystemsProcessor : BasePacketProcessor<LobbyResponseUpdateSolarSystems>

--- a/Scripts/Patches/GuideMissionStandardMode/Skip.cs
+++ b/Scripts/Patches/GuideMissionStandardMode/Skip.cs
@@ -1,7 +1,6 @@
 ﻿using HarmonyLib;
 using UnityEngine;
-
-// using NebulaAPI;
+using NebulaCompatibility;
 
 namespace GalacticScale
 {
@@ -14,7 +13,7 @@ namespace GalacticScale
             //if (GS2.Vanilla) return true;
             if (GS2.IsMenuDemo) return true;
             //GS2.Warn(NebulaCompatibility.IsMasterClient.ToString());
-            if (GS2.NebulaClient) return false;
+            if (NebulaCompat.IsClient) return false;
             if (GS2.Failed) return false;
 
             GS2.Log("Checking gameData... " + (_gameData == null ? "Null" : "Exists"));
@@ -37,7 +36,7 @@ namespace GalacticScale
                 {
                     __instance.gameData.localPlanet = GameMain.localPlanet;
                 }
-                else if (NebulaAPI.NebulaModAPI.IsMultiplayerActive && NebulaAPI.NebulaModAPI.MultiplayerSession.LocalPlayer.IsClient)
+                else if (NebulaCompat.IsMultiplayerActive && NebulaCompat.IsClient)
                 {
                     // let clients join in space if they want to
                     return false;

--- a/Scripts/Patches/UIGalaxySelect/EnterGame.cs
+++ b/Scripts/Patches/UIGalaxySelect/EnterGame.cs
@@ -1,5 +1,5 @@
 ﻿using HarmonyLib;
-using NebulaAPI;
+using NebulaCompatibility;
 
 namespace GalacticScale
 {
@@ -9,7 +9,7 @@ namespace GalacticScale
         [HarmonyPatch(typeof(UIGalaxySelect), "EnterGame")]
         public static void EnterGame(ref GameDesc ___gameDesc)
         {
-            if (GS2.Config.SkipPrologue && NebulaModAPI.MultiplayerSession == null) DSPGame.StartGameSkipPrologue(___gameDesc);
+            if (GS2.Config.SkipPrologue && !NebulaCompat.IsMultiplayerActive) DSPGame.StartGameSkipPrologue(___gameDesc);
         }
     }
 }

--- a/Scripts/Patches/UIGalaxySelect/SetStarMapGalaxy.cs
+++ b/Scripts/Patches/UIGalaxySelect/SetStarMapGalaxy.cs
@@ -1,5 +1,5 @@
 ﻿using HarmonyLib;
-using NebulaAPI;
+using NebulaCompatibility;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -12,10 +12,10 @@ namespace GalacticScale
         public static bool SetStarmapGalaxy(ref UIGalaxySelect __instance)
         {
             GS2.Warn("B");
-            if (NebulaModAPI.MultiplayerSession != null && NebulaModAPI.MultiplayerSession.LocalPlayer.IsClient && !GSSettings.lobbyReceivedUpdateValues)
+            if (NebulaCompat.IsMultiplayerActive && NebulaCompat.IsClient && !GSSettings.lobbyReceivedUpdateValues)
             {
                 GS2.Warn("Running Nebula Code");
-                NebulaModAPI.MultiplayerSession.Network.SendPacket(new LobbyRequestUpdateSolarSystems());
+                NebulaCompat.SendPacket(new LobbyRequestUpdateSolarSystems());
                 GS2.Warn("Nebula Requested Update");
                 return false;
             }
@@ -104,7 +104,7 @@ namespace GalacticScale
                 return;
             }
             GS2.Warn("A");
-            if (NebulaModAPI.MultiplayerSession == null)
+            if (!NebulaCompat.IsMultiplayerActive)
             {
                 GS2.Log("Nebula Null, Returning from Postfix");
             

--- a/Scripts/Patches/UIVirtualStarmap/OnGalaxyDataReset.cs
+++ b/Scripts/Patches/UIVirtualStarmap/OnGalaxyDataReset.cs
@@ -1,5 +1,5 @@
 ﻿using HarmonyLib;
-using NebulaAPI;
+using NebulaCompatibility;
 using UnityEngine;
 
 namespace GalacticScale
@@ -12,7 +12,7 @@ namespace GalacticScale
         {
             //GS2.Error("............................................");
             if (GS2.Vanilla) return true;
-            if (NebulaModAPI.NebulaIsInstalled) return true;
+            if (NebulaCompat.NebulaIsInstalled) return true;
             foreach (var starNode in __instance.starPool)
             {
                 starNode.active = false;

--- a/Scripts/Patches/UIVirtualStarmap/_OnLateUpdate.cs
+++ b/Scripts/Patches/UIVirtualStarmap/_OnLateUpdate.cs
@@ -1,5 +1,6 @@
 ﻿using HarmonyLib;
 using NebulaAPI;
+using NebulaCompatibility;
 using NGPT;
 using UnityEngine;
 

--- a/thunderstore.toml
+++ b/thunderstore.toml
@@ -11,7 +11,6 @@ containsNsfwContent = false
 
 [package.dependencies]
 "xiaoye97-BepInEx" = "5.4.17"
-"nebula-NebulaMultiplayerModApi" = "1.1.4"
 "crecheng-CloseError" = "1.0.0"
 
 [build]


### PR DESCRIPTION
Make soft dependency following the guide in R2Wiki [Mod Compatibility: Soft Dependency](https://github.com/risk-of-thunder/R2Wiki/wiki/Mod-Compatibility%3A-Soft-Dependency)

Add ``NebulaCompatibility`` namespace to include all classes that use NebulaAPI.  
Add ``NebulaCompat`` wrapper class to safely call NebulaAPI functions.  